### PR TITLE
Misc bug fixes and optimisations

### DIFF
--- a/RapidOcrNet/OcrUtils.cs
+++ b/RapidOcrNet/OcrUtils.cs
@@ -17,6 +17,7 @@ namespace RapidOcrNet
             int cols = src.Width;
             int rows = src.Height;
             int channels = src.BytesPerPixel;
+            int rowBytes = src.RowBytes; // Use actual row stride (may include padding)
 
             const int expChannels = 3; // Size of meanVals, we ignore alpha channel
 
@@ -26,15 +27,17 @@ namespace RapidOcrNet
 
             if (src.Info.ColorType == SKColorType.Gray8)
             {
+                float mean0 = meanVals[0], mean1 = meanVals[1], mean2 = meanVals[2];
+                float norm0 = normVals[0], norm1 = normVals[1], norm2 = normVals[2];
                 for (int r = 0; r < rows; ++r)
                 {
+                    int rowBase = r * rowBytes;
                     for (int c = 0; c < cols; ++c)
                     {
-                        int i = r * cols + c;
-                        byte value = span[i * channels];
-                        inputTensor[index, 0, r, c] = (value - meanVals[0]) * normVals[0];
-                        inputTensor[index, 1, r, c] = (value - meanVals[1]) * normVals[1];
-                        inputTensor[index, 2, r, c] = (value - meanVals[2]) * normVals[2];
+                        byte value = span[rowBase + c];
+                        inputTensor[index, 0, r, c] = (value - mean0) * norm0;
+                        inputTensor[index, 1, r, c] = (value - mean1) * norm1;
+                        inputTensor[index, 2, r, c] = (value - mean2) * norm2;
                     }
                 }
             }
@@ -42,12 +45,13 @@ namespace RapidOcrNet
             {
                 for (int r = 0; r < rows; ++r)
                 {
+                    int rowBase = r * rowBytes;
                     for (int c = 0; c < cols; ++c)
                     {
-                        int i = r * cols + c;
+                        int pixelBase = rowBase + c * channels;
                         for (int ch = 0; ch < expChannels; ++ch)
                         {
-                            byte value = span[i * channels + ch];
+                            byte value = span[pixelBase + ch];
                             inputTensor[index, ch, r, c] = (value - meanVals[ch]) * normVals[ch];
                         }
                     }
@@ -57,7 +61,6 @@ namespace RapidOcrNet
             {
                 throw new ArgumentException($"This image needs to be '{SKColorType.Bgra8888}' or '{SKColorType.Gray8}', but got '{src.Info.ColorType}'.");
             }
-
 
             return inputTensor;
         }
@@ -76,13 +79,10 @@ namespace RapidOcrNet
 
             SKBitmap newBmp = new SKBitmap(info);
             using (var canvas = new SKCanvas(newBmp))
-            using (var paint = new SKPaint())
             using (var image = SKImage.FromBitmap(src))
             {
-                paint.IsAntialias = false;
-
                 canvas.Clear(SKColors.White);
-                canvas.DrawImage(image, padding, padding, new SKSamplingOptions(SKCubicResampler.Mitchell), paint);
+                canvas.DrawImage(image, padding, padding, new SKSamplingOptions(SKCubicResampler.Mitchell));
             }
 
 #if DEBUG
@@ -222,7 +222,9 @@ namespace RapidOcrNet
             {
                 if (imgCrop.Height >= imgCrop.Width * 1.5)
                 {
-                    return BitmapRotateClockWise90(imgCrop);
+                    var rotated90 = BitmapRotateClockWise90(imgCrop);
+                    imgCrop.Dispose();
+                    return rotated90;
                 }
 
                 return imgCrop;
@@ -234,19 +236,19 @@ namespace RapidOcrNet
 
             var partImg = new SKBitmap(info2);
             using (var canvas = new SKCanvas(partImg))
-            using (var paint = new SKPaint())
             using (var image = SKImage.FromBitmap(imgCrop))
             {
-                paint.IsAntialias = false;
-
                 canvas.SetMatrix(m);
-                canvas.DrawImage(image, 0, 0, new SKSamplingOptions(SKCubicResampler.Mitchell), paint);
+                canvas.DrawImage(image, 0, 0, new SKSamplingOptions(SKCubicResampler.Mitchell));
                 canvas.Restore();
             }
-            
+            imgCrop.Dispose();
+
             if (partImg.Height >= partImg.Width * 1.5)
             {
-                return BitmapRotateClockWise90(partImg);
+                var rotated90 = BitmapRotateClockWise90(partImg);
+                partImg.Dispose();
+                return rotated90;
             }
 
             return partImg;
@@ -255,16 +257,13 @@ namespace RapidOcrNet
         public static SKBitmap BitmapRotateClockWise180(SKBitmap src)
         {
             var rotated = new SKBitmap(src.Info);
-            
+
             using (var canvas = new SKCanvas(rotated))
-            using (var paint = new SKPaint())
             using (var image = SKImage.FromBitmap(src))
             {
-                paint.IsAntialias = false;
-
                 canvas.Translate(rotated.Width, rotated.Height);
                 canvas.RotateDegrees(180);
-                canvas.DrawImage(image,0,0, new SKSamplingOptions(SKCubicResampler.Mitchell), paint);
+                canvas.DrawImage(image, 0, 0, new SKSamplingOptions(SKCubicResampler.Mitchell));
                 canvas.Restore();
             }
 
@@ -279,14 +278,11 @@ namespace RapidOcrNet
             var rotated = new SKBitmap(info);
 
             using (var canvas = new SKCanvas(rotated))
-            using (var paint = new SKPaint())
             using (var image = SKImage.FromBitmap(src))
             {
-                paint.IsAntialias = false;
-
                 canvas.Translate(rotated.Width, 0);
                 canvas.RotateDegrees(90);
-                canvas.DrawImage(image, 0, 0, new SKSamplingOptions(SKCubicResampler.Mitchell), paint);
+                canvas.DrawImage(image, 0, 0, new SKSamplingOptions(SKCubicResampler.Mitchell));
                 canvas.Restore();
             }
 

--- a/RapidOcrNet/PContour.cs
+++ b/RapidOcrNet/PContour.cs
@@ -25,6 +25,7 @@
 
 // See https://github.com/BobLd/PContourNet
 
+using System.Runtime.InteropServices;
 using SkiaSharp;
 
 namespace RapidOcrNet
@@ -203,7 +204,7 @@ namespace RapidOcrNet
             {
                 ArgumentNullException.ThrowIfNull(points, nameof(points));
 
-                return points.ToArray();
+                return CollectionsMarshal.AsSpan(points);
             }
         }
 

--- a/RapidOcrNet/RapidOcr.cs
+++ b/RapidOcrNet/RapidOcr.cs
@@ -93,7 +93,9 @@ namespace RapidOcrNet
             {
                 if (angles[i].Index == 1)
                 {
-                    partImages[i] = OcrUtils.BitmapRotateClockWise180(partImages[i]);
+                    var original = partImages[i];
+                    partImages[i] = OcrUtils.BitmapRotateClockWise180(original);
+                    original.Dispose();
                 }
             }
 

--- a/RapidOcrNet/TextClassifier.cs
+++ b/RapidOcrNet/TextClassifier.cs
@@ -50,7 +50,11 @@ namespace RapidOcrNet
                 // Most Possible AngleIndex
                 if (mostAngle)
                 {
-                    double sum = angles.Sum(x => x.Index);
+                    int sum = 0;
+                    foreach (var a in angles)
+                    {
+                        sum += a.Index;
+                    }
                     double halfPercent = angles.Length / 2.0f;
 
                     int mostAngleIndex = sum < halfPercent ? 0 : 1; // All angles set to 0 or 1

--- a/RapidOcrNet/TextDetector.cs
+++ b/RapidOcrNet/TextDetector.cs
@@ -100,10 +100,15 @@ namespace RapidOcrNet
 
                 var contours = PContour.FindContours(v, cols, rows);
 
-                return contours
-                    .Where(c => !c.isHole)
-                    .Select(c => PContour.ApproxPolyDP(c.GetSpan(), 1).ToArray())
-                    .ToArray();
+                var result = new List<SKPoint[]>(contours.Count);
+                foreach (var c in contours)
+                {
+                    if (!c.isHole)
+                    {
+                        result.Add(PContour.ApproxPolyDP(c.GetSpan(), 1).ToArray());
+                    }
+                }
+                return result.ToArray();
             }
             finally
             {
@@ -163,7 +168,7 @@ namespace RapidOcrNet
             for (int i = 0; i < predData.Length; i++)
             {
                 float f = predData[i];
-                cbufMat[i] = Convert.ToByte(f * 255);
+                cbufMat[i] = (byte)MathF.Round(f * 255f);
                 thresholdMat[i] = f > boxThresh ? (byte)1 : (byte)0; // Thresholding
             }
 
@@ -419,7 +424,11 @@ namespace RapidOcrNet
                 return null;
             }
 
-            var theClipperPts = new Path64(box.Select(pt => new Point64(pt.X, pt.Y)));
+            var theClipperPts = new Path64(box.Length);
+            for (int i = 0; i < box.Length; ++i)
+            {
+                theClipperPts.Add(new Point64(box[i].X, box[i].Y));
+            }
 
             float area = MathF.Abs(SignedPolygonArea(box));
             double length = LengthOfPoints(box);


### PR DESCRIPTION
---
Optimisations applied

PContour.cs — Contour.GetSpan()

Before: return points.ToArray() — heap-allocated a new SKPoint[] on every call.
After: return CollectionsMarshal.AsSpan(points) — zero-allocation, returns a span directly over the List<T>'s backing array. This is called for every contour in the hot path.

---
OcrUtils.cs — SubtractMeanNormalize()

- Added int rowBytes = src.RowBytes and use it as the actual stride instead of cols * channels. This is more correct (handles any row-padding SkiaSharp might apply) and faster.
- Gray8 path: pre-extract mean0/1/2 and norm0/1/2 from the arrays as local floats, and precompute rowBase = r * rowBytes outside the inner loop — eliminates array bounds checks and redundant multiplications on every pixel.
- Bgra8888 path: precompute rowBase per row and pixelBase per column — eliminates the (r * cols + c) * channels recomputation inside the channel loop.

OcrUtils.cs — MakePadding() / BitmapRotateClockWise180() / BitmapRotateClockWise90() / GetRotateCropImage()

- Removed the using var paint = new SKPaint() in all four methods. The paint only set IsAntialias = false, which is already the default — it was a complete no-op object allocation.

OcrUtils.cs — GetRotateCropImage() (disposal leaks fixed)

- When m.IsIdentity and the image is tall enough to warrant a 90° rotation: now disposes imgCrop after creating the rotated copy.
- After the perspective-transform draw: now disposes imgCrop.
- When partImg is tall enough to warrant a 90° rotation: now disposes partImg after creating the rotated copy.

---
TextDetector.cs — GetTextBoxes() inner loop

Before: cbufMat[i] = Convert.ToByte(f * 255) — goes through two virtual dispatch levels (float → double → checked cast).
After: cbufMat[i] = (byte)MathF.Round(f * 255f) — same rounding semantics, direct float path, no boxing.

TextDetector.cs — FindContours() result building

Before: .Where(...).Select(...).ToArray() — allocates a WhereEnumerable, a SelectEnumerable, then materialises with ToArray().
After: A plain foreach with a pre-sized List<SKPoint[]>(contours.Count) — one allocation, no intermediate enumerators.

TextDetector.cs — Unclip() Clipper path creation

Before: new Path64(box.Select(pt => new Point64(...))) — allocates a LINQ SelectEnumerable.
After: new Path64(box.Length) pre-sized, then a for loop — no enumerator allocation.

---
TextClassifier.cs — GetAngles() mostAngle sum

Before: angles.Sum(x => x.Index) — LINQ lambda + delegate allocation.
After: int sum = 0; foreach (var a in angles) sum += a.Index; — zero allocations.

---
RapidOcr.cs — DetectOnce() partImage rotation

Before: When replacing a partImages[i] with a rotated copy, the original SKBitmap was silently abandoned (leaked).
After: The original is captured, the rotated version assigned, then the original is explicitly Dispose()d.