### PR TITLE
Add optional CancellationToken and progress reporting to Detect

### DIFF
--- a/RapidOcrNet.Tests/CancellationTest.cs
+++ b/RapidOcrNet.Tests/CancellationTest.cs
@@ -108,6 +108,39 @@ public class CancellationTest
         Assert.Single(angles);
     }
 
+    /// <summary>
+    /// Invokes the handler inline. <see cref="Progress{T}"/> posts to a synchronization context,
+    /// so with none installed its reports land on the thread pool and a test could assert against
+    /// a list that has not filled yet — passing whether or not anything was ever reported.
+    /// </summary>
+    private sealed class SyncProgress<T>(Action<T> handler) : IProgress<T>
+    {
+        public void Report(T value) => handler(value);
+    }
+
+    [Fact]
+    public void ProgressIsReportedOncePerRecognisedLine()
+    {
+        var reports = new List<(int Completed, int Total)>();
+        using SKBitmap originSrc = LoadImage("en_rec.jpg");
+
+        var result = Engine.Value.Detect(originSrc, RapidOcrOptions.Default,
+            CancellationToken.None,
+            new SyncProgress<(int Completed, int Total)>(reports.Add));
+
+        Assert.NotEmpty(reports);
+
+        // One report per detected line, counting up, with a total that never moves.
+        int total = reports[0].Total;
+        Assert.Equal(total, reports.Count);
+        Assert.Equal(Enumerable.Range(1, total), reports.Select(r => r.Completed));
+        Assert.All(reports, r => Assert.Equal(total, r.Total));
+
+        // Detected lines are what progress counts; blocks can be fewer, since recognition drops
+        // those below the text-score threshold.
+        Assert.True(total >= result.TextBlocks.Length);
+    }
+
     [Fact]
     public void UncancelledTokenChangesNothing()
     {

--- a/RapidOcrNet.Tests/CancellationTest.cs
+++ b/RapidOcrNet.Tests/CancellationTest.cs
@@ -1,0 +1,128 @@
+using SkiaSharp;
+
+namespace RapidOcrNet.Tests;
+
+/// <summary>
+/// Cancellation of a <see cref="RapidOcr.Detect(SKBitmap, RapidOcrOptions, CancellationToken)"/>
+/// call. A page is not interruptible mid-inference, so what these pin is that the token is
+/// observed at every boundary where it can be, and that giving up leaves nothing behind.
+/// </summary>
+public class CancellationTest
+{
+    private static readonly Lazy<RapidOcr> Engine = new(() =>
+    {
+        var ocr = new RapidOcr();
+        ocr.InitModels();
+        return ocr;
+    });
+
+    private static SKBitmap LoadImage(string name)
+    {
+        var path = Path.Combine("images", name);
+        Assert.True(File.Exists(path));
+        return SKBitmap.Decode(path);
+    }
+
+    [Fact]
+    public void DetectThrowsWhenAlreadyCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        using SKBitmap originSrc = LoadImage("en_rec.jpg");
+
+        Assert.Throws<OperationCanceledException>(
+            () => Engine.Value.Detect(originSrc, RapidOcrOptions.Default, cts.Token));
+    }
+
+    [Fact]
+    public void DetectBoxesThrowsWhenAlreadyCancelled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        using SKBitmap originSrc = LoadImage("en_rec.jpg");
+
+        Assert.Throws<OperationCanceledException>(
+            () => Engine.Value.DetectBoxes(originSrc, RapidOcrOptions.Default, cts.Token));
+    }
+
+    [Fact]
+    public void DetectStopsBetweenCropsOnceCancelled()
+    {
+        // Cancelled from another thread while the page is being recognised, which is the case the
+        // token exists for: recognition is one inference per detected line, so the call returns
+        // after the line in flight rather than after the whole page.
+        using var cts = new CancellationTokenSource();
+        using SKBitmap originSrc = LoadImage("en_rec.jpg");
+
+        cts.CancelAfter(TimeSpan.FromMilliseconds(1));
+
+        try
+        {
+            var result = Engine.Value.Detect(originSrc, RapidOcrOptions.Default, cts.Token);
+
+            // Fast machine, small image: the page can legitimately finish before the timer fires.
+            // Completing is a valid outcome; producing a partial or corrupt result is not.
+            Assert.NotNull(result.TextBlocks);
+        }
+        catch (OperationCanceledException)
+        {
+            // The outcome under test.
+        }
+    }
+
+    [Fact]
+    public void RecognizerObservesTheTokenPerCrop()
+    {
+        // Pinned at the stage rather than through Detect, because Detect's own boundary checks
+        // would throw first and hide whether the per-crop check exists at all. The token is
+        // tested before the crop is touched, so no model needs to be loaded.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Not disposed: Dispose() on an instance that never had InitModel called throws, which
+        // is unrelated to what this pins, and an uninitialised stage holds no native handle.
+        var recognizer = new TextRecognizer();
+        using var crop = new SKBitmap(32, 48);
+
+        Assert.Throws<OperationCanceledException>(() => recognizer.GetTextLines([crop], cts.Token));
+    }
+
+    [Fact]
+    public void ClassifierObservesTheTokenPerCrop()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var classifier = new TextClassifier();   // see note above on disposal
+        using var crop = new SKBitmap(32, 48);
+
+        Assert.Throws<OperationCanceledException>(
+            () => classifier.GetAngles([crop], doAngle: true, mostAngle: false,
+                preserveAspectRatio: false, cancellationToken: cts.Token));
+
+        // The no-angle path does no work, so it has nothing to interrupt and must not throw.
+        var angles = classifier.GetAngles([crop], doAngle: false, mostAngle: false,
+            preserveAspectRatio: false, cancellationToken: cts.Token);
+        Assert.Single(angles);
+    }
+
+    [Fact]
+    public void UncancelledTokenChangesNothing()
+    {
+        // The default path has to stay byte-for-byte what it was: CancellationToken.None must
+        // produce exactly the result the parameterless overload does.
+        using SKBitmap a = LoadImage("en_rec.jpg");
+        using SKBitmap b = LoadImage("en_rec.jpg");
+
+        var withoutToken = Engine.Value.Detect(a, RapidOcrOptions.Default);
+        var withToken = Engine.Value.Detect(b, RapidOcrOptions.Default, CancellationToken.None);
+
+        Assert.Equal(withoutToken.TextBlocks.Length, withToken.TextBlocks.Length);
+        for (int i = 0; i < withoutToken.TextBlocks.Length; i++)
+        {
+            Assert.Equal(withoutToken.TextBlocks[i].Text, withToken.TextBlocks[i].Text);
+        }
+    }
+}

--- a/RapidOcrNet/RapidOcr.cs
+++ b/RapidOcrNet/RapidOcr.cs
@@ -88,7 +88,8 @@ public sealed class RapidOcr : IDisposable
 
     /// <inheritdoc cref="Detect(SKBitmap, RapidOcrOptions, CancellationToken)"/>
     public OcrResult Detect(string path, RapidOcrOptions options,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        IProgress<(int Completed, int Total)>? progress = null)
     {
         if (!File.Exists(path))
         {
@@ -97,7 +98,7 @@ public sealed class RapidOcr : IDisposable
 
         using (var originSrc = SKBitmap.Decode(path))
         {
-            return Detect(originSrc, options, cancellationToken);
+            return Detect(originSrc, options, cancellationToken, progress);
         }
     }
 
@@ -111,8 +112,13 @@ public sealed class RapidOcr : IDisposable
     /// <exception cref="OperationCanceledException">
     /// <paramref name="cancellationToken"/> was cancelled before the next stage or crop.
     /// </exception>
+    /// <param name="progress">
+    /// Reported during recognition as (lines recognised, lines detected). Nothing is reported
+    /// before detection finishes, because the line count is not known until then.
+    /// </param>
     public OcrResult Detect(SKBitmap originSrc, RapidOcrOptions options,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        IProgress<(int Completed, int Total)>? progress = null)
     {
         using var input = PrepareDetectorInput(originSrc, options);
         return DetectOnce(input,
@@ -121,7 +127,7 @@ public sealed class RapidOcr : IDisposable
             options.ReturnWordBox, options.ReturnSingleCharBox,
             options.TextScore, options.ClsThresh,
             options.ClsPreserveAspectRatio,
-            cancellationToken);
+            cancellationToken, progress);
     }
 
     /// <summary>
@@ -296,7 +302,8 @@ public sealed class RapidOcr : IDisposable
     private OcrResult DetectOnce(in DetectorInput input, float boxScoreThresh,
         float boxThresh, float unClipRatio, bool doAngle, bool mostAngle,
         bool returnWordBox, bool returnSingleCharBox, float textScore, float clsThresh,
-        bool clsPreserveAspectRatio, CancellationToken cancellationToken = default)
+        bool clsPreserveAspectRatio, CancellationToken cancellationToken = default,
+        IProgress<(int Completed, int Total)>? progress = null)
     {
         SKBitmap src = input.Bitmap;
 
@@ -354,7 +361,7 @@ public sealed class RapidOcr : IDisposable
             }
 
             // step: crnnNet getTextLines
-            textLines = _textRecognizer.GetTextLines(partImages, cancellationToken);
+            textLines = _textRecognizer.GetTextLines(partImages, cancellationToken, progress);
         }
         finally
         {

--- a/RapidOcrNet/RapidOcr.cs
+++ b/RapidOcrNet/RapidOcr.cs
@@ -86,7 +86,9 @@ public sealed class RapidOcr : IDisposable
         _textRecognizer.InitModel(models.RecModelPath, models.KeysPath, op);
     }
 
-    public OcrResult Detect(string path, RapidOcrOptions options)
+    /// <inheritdoc cref="Detect(SKBitmap, RapidOcrOptions, CancellationToken)"/>
+    public OcrResult Detect(string path, RapidOcrOptions options,
+        CancellationToken cancellationToken = default)
     {
         if (!File.Exists(path))
         {
@@ -95,11 +97,22 @@ public sealed class RapidOcr : IDisposable
 
         using (var originSrc = SKBitmap.Decode(path))
         {
-            return Detect(originSrc, options);
+            return Detect(originSrc, options, cancellationToken);
         }
     }
 
-    public OcrResult Detect(SKBitmap originSrc, RapidOcrOptions options)
+    /// <param name="cancellationToken">
+    /// Observed at every stage boundary, and between crops within the angle-classification and
+    /// recognition stages. A page is not interruptible mid-inference — the detector is a single
+    /// ONNX run — but recognition is one inference per detected line, so an abandoned page stops
+    /// after the current line rather than after the whole page. On a large model set that is
+    /// seconds instead of minutes.
+    /// </param>
+    /// <exception cref="OperationCanceledException">
+    /// <paramref name="cancellationToken"/> was cancelled before the next stage or crop.
+    /// </exception>
+    public OcrResult Detect(SKBitmap originSrc, RapidOcrOptions options,
+        CancellationToken cancellationToken = default)
     {
         using var input = PrepareDetectorInput(originSrc, options);
         return DetectOnce(input,
@@ -107,7 +120,8 @@ public sealed class RapidOcr : IDisposable
             options.DoAngle, options.MostAngle,
             options.ReturnWordBox, options.ReturnSingleCharBox,
             options.TextScore, options.ClsThresh,
-            options.ClsPreserveAspectRatio);
+            options.ClsPreserveAspectRatio,
+            cancellationToken);
     }
 
     /// <summary>
@@ -121,7 +135,8 @@ public sealed class RapidOcr : IDisposable
     /// <param name="options">Detection options. Recognition-only fields (TextScore,
     /// ReturnWordBox, ClsThresh, etc.) are ignored on this path.</param>
     /// <returns>Boxes in source-image coordinates, sorted in reading order.</returns>
-    public IReadOnlyList<TextBox> DetectBoxes(string path, RapidOcrOptions options)
+    public IReadOnlyList<TextBox> DetectBoxes(string path, RapidOcrOptions options,
+        CancellationToken cancellationToken = default)
     {
         if (!File.Exists(path))
         {
@@ -130,7 +145,7 @@ public sealed class RapidOcr : IDisposable
 
         using (var originSrc = SKBitmap.Decode(path))
         {
-            return DetectBoxes(originSrc, options);
+            return DetectBoxes(originSrc, options, cancellationToken);
         }
     }
 
@@ -138,8 +153,11 @@ public sealed class RapidOcr : IDisposable
     /// Runs the detection stage only and returns the raw text boxes, skipping angle
     /// classification and recognition. See <see cref="DetectBoxes(string, RapidOcrOptions)"/>.
     /// </summary>
-    public IReadOnlyList<TextBox> DetectBoxes(SKBitmap originSrc, RapidOcrOptions options)
+    public IReadOnlyList<TextBox> DetectBoxes(SKBitmap originSrc, RapidOcrOptions options,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var input = PrepareDetectorInput(originSrc, options);
         var textBoxes = _textDetector.GetTextBoxes(input.Bitmap, input.Scale,
             options.BoxScoreThresh, options.BoxThresh, options.UnClipRatio) ?? [];
@@ -278,16 +296,22 @@ public sealed class RapidOcr : IDisposable
     private OcrResult DetectOnce(in DetectorInput input, float boxScoreThresh,
         float boxThresh, float unClipRatio, bool doAngle, bool mostAngle,
         bool returnWordBox, bool returnSingleCharBox, float textScore, float clsThresh,
-        bool clsPreserveAspectRatio)
+        bool clsPreserveAspectRatio, CancellationToken cancellationToken = default)
     {
         SKBitmap src = input.Bitmap;
 
         // Start detect
         var sw = ValueStopwatch.StartNew();
 
+        cancellationToken.ThrowIfCancellationRequested();
+
         // step: dbNet getTextBoxes
         var textBoxes = _textDetector.GetTextBoxes(src, input.Scale, boxScoreThresh, boxThresh, unClipRatio) ?? [];
         var dbNetTime = sw.ElapsedMilliseconds;
+
+        // Cheapest place to abandon a page: detection is done, but the per-line stages that
+        // dominate the cost have not started, and no crops have been allocated yet.
+        cancellationToken.ThrowIfCancellationRequested();
 
         // getPartImages: capture crop bookkeeping when word boxes are requested.
         // Both overloads now dispose partial results internally if a crop throws midway.
@@ -304,32 +328,42 @@ public sealed class RapidOcr : IDisposable
         }
 
         // step: angleNet getAngles
-        Angle[] angles = _textClassifier.GetAngles(partImages, doAngle, mostAngle, clsPreserveAspectRatio);
-
-        // Rotate partImgs only if the classifier is confident enough (Python <c>cls_thresh</c>).
-        // Without this gate, low-confidence flips wrongly invert clean upright text and the
-        // recognizer produces garbage like "1997" → "L66" or "This" → "s".
-        for (int i = 0; i < partImages.Length; ++i)
+        Angle[] angles;
+        TextLine[] textLines;
+        try
         {
-            if (angles[i].Index == 1 && angles[i].Score >= clsThresh)
+            angles = _textClassifier.GetAngles(partImages, doAngle, mostAngle, clsPreserveAspectRatio,
+                cancellationToken);
+
+            // Rotate partImgs only if the classifier is confident enough (Python <c>cls_thresh</c>).
+            // Without this gate, low-confidence flips wrongly invert clean upright text and the
+            // recognizer produces garbage like "1997" → "L66" or "This" → "s".
+            for (int i = 0; i < partImages.Length; ++i)
             {
-                var original = partImages[i];
-                partImages[i] = OcrUtils.BitmapRotateClockWise180(original);
-                original.Dispose();
+                if (angles[i].Index == 1 && angles[i].Score >= clsThresh)
+                {
+                    var original = partImages[i];
+                    partImages[i] = OcrUtils.BitmapRotateClockWise180(original);
+                    original.Dispose();
+                }
+                else if (angles[i].Index == 1)
+                {
+                    // Below threshold, treat as no-flip for downstream consumers / word-box mapping.
+                    angles[i].Index = 0;
+                }
             }
-            else if (angles[i].Index == 1)
-            {
-                // Below threshold, treat as no-flip for downstream consumers / word-box mapping.
-                angles[i].Index = 0;
-            }
+
+            // step: crnnNet getTextLines
+            textLines = _textRecognizer.GetTextLines(partImages, cancellationToken);
         }
-
-        // step: crnnNet getTextLines
-        TextLine[] textLines = _textRecognizer.GetTextLines(partImages);
-
-        foreach (var bmp in partImages)
+        finally
         {
-            bmp.Dispose();
+            // Cancellation unwinds through here as well. The crops are native Skia bitmaps, so
+            // leaking them on an abandoned page would be the one lasting cost of giving up.
+            foreach (var bmp in partImages)
+            {
+                bmp?.Dispose();
+            }
         }
 
         var textBlocks = new TextBlock[textLines.Length];

--- a/RapidOcrNet/TextClassifier.cs
+++ b/RapidOcrNet/TextClassifier.cs
@@ -61,13 +61,19 @@ public sealed class TextClassifier : IDisposable
         InitModel(path, sessionOptions);
     }
 
-    public Angle[] GetAngles(SKBitmap[] partImgs, bool doAngle, bool mostAngle, bool preserveAspectRatio = false)
+    /// <param name="cancellationToken">
+    /// Observed between crops, which is one ONNX inference each. Only meaningful when
+    /// <paramref name="doAngle"/> is set; the no-angle path does no work to interrupt.
+    /// </param>
+    public Angle[] GetAngles(SKBitmap[] partImgs, bool doAngle, bool mostAngle,
+        bool preserveAspectRatio = false, CancellationToken cancellationToken = default)
     {
         var angles = new Angle[partImgs.Length];
         if (doAngle)
         {
             for (int i = 0; i < partImgs.Length; i++)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 angles[i] = GetAngle(partImgs[i], preserveAspectRatio);
             }
 

--- a/RapidOcrNet/TextRecognizer.cs
+++ b/RapidOcrNet/TextRecognizer.cs
@@ -62,7 +62,14 @@ public sealed class TextRecognizer : IDisposable
         }
     }
 
-    public TextLine[] GetTextLines(SKBitmap[] partImgs)
+    /// <param name="partImgs">Cropped text-line images, in detection order.</param>
+    /// <param name="cancellationToken">
+    /// Observed between crops. Recognition runs one ONNX inference per crop, so a crop boundary
+    /// is the finest granularity this stage can offer: a caller abandoning a page stops after the
+    /// current line instead of after the whole page. On a heavy model set that is the difference
+    /// between about a second and about a minute.
+    /// </param>
+    public TextLine[] GetTextLines(SKBitmap[] partImgs, CancellationToken cancellationToken = default)
     {
         // NOTE: Python's pipeline batches crops by aspect ratio and zero-right-pads
         // each crop to 48 * max(w/h, 320/48) so the recognizer sees its training
@@ -74,6 +81,7 @@ public sealed class TextRecognizer : IDisposable
         var textLines = new TextLine[partImgs.Length];
         for (int i = 0; i < partImgs.Length; i++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             textLines[i] = GetTextLine(partImgs[i]);
         }
         return textLines;

--- a/RapidOcrNet/TextRecognizer.cs
+++ b/RapidOcrNet/TextRecognizer.cs
@@ -69,7 +69,12 @@ public sealed class TextRecognizer : IDisposable
     /// current line instead of after the whole page. On a heavy model set that is the difference
     /// between about a second and about a minute.
     /// </param>
-    public TextLine[] GetTextLines(SKBitmap[] partImgs, CancellationToken cancellationToken = default)
+    /// <param name="progress">
+    /// Reported after each crop as (recognised, total). Recognition is the long pole of a page and
+    /// its cost is per line, so this is the only stage where a caller can show real movement.
+    /// </param>
+    public TextLine[] GetTextLines(SKBitmap[] partImgs, CancellationToken cancellationToken = default,
+        IProgress<(int Completed, int Total)>? progress = null)
     {
         // NOTE: Python's pipeline batches crops by aspect ratio and zero-right-pads
         // each crop to 48 * max(w/h, 320/48) so the recognizer sees its training
@@ -83,6 +88,7 @@ public sealed class TextRecognizer : IDisposable
         {
             cancellationToken.ThrowIfCancellationRequested();
             textLines[i] = GetTextLine(partImgs[i]);
+            progress?.Report((i + 1, partImgs.Length));
         }
         return textLines;
     }


### PR DESCRIPTION
Two independent, optional-parameter additions to `Detect`: a `CancellationToken` and an `IProgress`. Either commit can be taken on its own, and every existing call site compiles and behaves unchanged.

### Why

Recognition dominates the cost of a page, and there is currently no way to abandon one or to see how far it has got. Measured on a 1920 px page with 34 text lines, best of two passes on a 20-core box:

| Model set | detect | recognise | full |
|---|---|---|---|
| PP-OCRv5 Latin | 0.8 s | 1.0 s | 1.8 s |
| PP-OCRv6 Tiny | 1.6 s | 0.7 s | 2.3 s |
| PP-OCRv6 Small | 2.6 s | 1.9 s | 4.5 s |
| PP-OCRv6 Medium | 15.3 s | **52.2 s** | **67.5 s** |

In a document viewer this is a scheduling problem rather than just a slow call: a user who closes the document, navigates away or changes a setting currently waits out the whole page first.

### What the token can and cannot do

`GetTextLines` is one ONNX inference per crop, so a crop boundary is the finest granularity available — an abandoned page stops after the line in flight instead of after the page. At the Medium tier that is roughly 1.5 s instead of 52 s. Detection stays atomic, which is the cheaper half anyway.

The token is observed at each stage boundary and between crops in the angle-classification and recognition stages.

Crop disposal moved into a `finally` so cancellation unwinds through it — the crops are native Skia bitmaps, and leaking them would have been the one lasting cost of giving up.

### Progress

Reported after each crop as `(Completed, Total)`. Nothing is reported before detection finishes, since the line count is not known until then. A value tuple rather than a new public type, so it adds no API surface beyond the parameter.

### Style notes

Optional parameters rather than overloads, matching the existing `GetAngles(..., bool preserveAspectRatio = false)`. Happy to switch to overloads if you would rather keep binary compatibility strict.

### Tests

Seven tests in `CancellationTest.cs`: both entry points with a pre-cancelled token, cancellation while running, `CancellationToken.None` producing the same result as the call without a token, and progress reporting one coherent, counting report per detected line.

The two per-crop checks are pinned at the stage rather than through `Detect`, because `Detect`'s own boundary check throws first and would hide whether the per-crop check exists at all. The progress test uses an inline `IProgress` rather than `Progress<T>`, since with no synchronization context installed `Progress<T>` posts to the thread pool and the assertions would pass whether or not anything was reported.

Full suite: 109 passed. The one failure, `OcrTestV6Small.OcrV6SmokeTest(medium)`, is a missing `models/v6/PP-OCRv6_det_medium.onnx` and reproduces identically on `master` without these commits. Library verified against both `net8.0` and `net10.0`.

### Unrelated thing I noticed

`TextRecognizer.Dispose()` and `TextClassifier.Dispose()` throw `NullReferenceException` when `InitModel` was never called. Left alone here as out of scope — happy to send a separate PR if useful.
