### PR TITLE
Don't throw from Dispose when InitModel was never called

### DIFF
--- a/RapidOcrNet.Tests/DisposeTest.cs
+++ b/RapidOcrNet.Tests/DisposeTest.cs
@@ -1,0 +1,61 @@
+namespace RapidOcrNet.Tests;
+
+/// <summary>
+/// Disposing an instance whose models were never loaded. Loading is separate from construction,
+/// so this is reachable whenever a load fails — and a <c>using</c> that throws on the way out
+/// replaces the real error (a missing model file) with a NullReferenceException.
+///
+/// <para>None of these need a model on disk, so they run everywhere.</para>
+/// </summary>
+public class DisposeTest
+{
+    [Fact]
+    public void TextRecognizerDisposesBeforeInit()
+    {
+        var recognizer = new TextRecognizer();
+        recognizer.Dispose();
+    }
+
+    [Fact]
+    public void TextClassifierDisposesBeforeInit()
+    {
+        var classifier = new TextClassifier();
+        classifier.Dispose();
+    }
+
+    [Fact]
+    public void TextDetectorDisposesBeforeInit()
+    {
+        var detector = new TextDetector();
+        detector.Dispose();
+    }
+
+    [Fact]
+    public void RapidOcrDisposesBeforeInit()
+    {
+        // The composite case, and the likeliest one to be hit: RapidOcr builds all three stages
+        // in its field initializers, so a caller that constructs it and never gets as far as
+        // InitModels still owns something disposable.
+        var ocr = new RapidOcr();
+        ocr.Dispose();
+    }
+
+    [Fact]
+    public void FailedInitLeavesTheOriginalErrorIntact()
+    {
+        // What the fix is actually for. Before it, the FileNotFoundException below was reported
+        // correctly but the `using` disposal then threw NullReferenceException over the top of
+        // it, so callers saw a null-reference error instead of "your model path is wrong".
+        var ocr = new RapidOcr();
+        try
+        {
+            Assert.Throws<FileNotFoundException>(() =>
+                ocr.InitModels("no-such-det.onnx", "no-such-cls.onnx", "no-such-rec.onnx",
+                    "no-such-keys.txt"));
+        }
+        finally
+        {
+            ocr.Dispose();
+        }
+    }
+}

--- a/RapidOcrNet/TextClassifier.cs
+++ b/RapidOcrNet/TextClassifier.cs
@@ -217,6 +217,7 @@ public sealed class TextClassifier : IDisposable
 
     public void Dispose()
     {
-        _angleNet.Dispose();
+        // See TextRecognizer.Dispose: null until InitModel has run.
+        _angleNet?.Dispose();
     }
 }

--- a/RapidOcrNet/TextDetector.cs
+++ b/RapidOcrNet/TextDetector.cs
@@ -604,7 +604,9 @@ public sealed class TextDetector : IDisposable
 
     public void Dispose()
     {
-        _dbNet.Dispose();
+        // See TextRecognizer.Dispose: null until InitModel has run. The Skia fields are
+        // assigned at construction, so they are always safe to dispose.
+        _dbNet?.Dispose();
         _dilatePaint.Dispose();
         _dilateFilter.Dispose();
     }

--- a/RapidOcrNet/TextRecognizer.cs
+++ b/RapidOcrNet/TextRecognizer.cs
@@ -274,6 +274,8 @@ public sealed class TextRecognizer : IDisposable
 
     public void Dispose()
     {
-        _crnnNet.Dispose();
+        // Null when InitModel was never reached: the models are loaded separately from
+        // construction, so a caller whose load failed still disposes a half-built instance.
+        _crnnNet?.Dispose();
     }
 }


### PR DESCRIPTION
Follow-up to #35, as requested.

`TextRecognizer`, `TextClassifier` and `TextDetector` assign their `InferenceSession` in `InitModel`, but `Dispose` assumed it was there. Since loading is separate from construction, any instance whose load did not complete throws `NullReferenceException` on the way out.

The case that bites is a wrong model path:

```csharp
using var ocr = new RapidOcr();
ocr.InitModels("wrong/path/det.onnx", ...);   // FileNotFoundException, correctly
                                              // ...then Dispose throws NullReferenceException over it
```

`InitModels` reports the missing file accurately, and then the `using` replaces that with a null-reference error — so the message the user actually sees is the one that tells them nothing. `RapidOcr` builds all three stages in its field initializers, so plain `new RapidOcr()` + `Dispose()` hits it as well.

Null-conditional on the three session fields. `TextDetector`'s `_dilatePaint` / `_dilateFilter` are assigned at construction, so those stay unconditional.

Five tests: each stage individually, the composite `RapidOcr` case, and a failed `InitModels` whose original exception has to survive disposal. None of them needs a model on disk, so they run anywhere — including in the new Actions workflow. All three stage tests fail with `NullReferenceException` without the fix.

Full suite on this branch: 131 passed, 7 skipped, 0 failed.
